### PR TITLE
Add host port allocation support (version1):

### DIFF
--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -476,6 +476,7 @@ func AddKubeletConfigFlags(fs *pflag.FlagSet, c *kubeletconfig.KubeletConfigurat
 	fs.Var(flag.NewMapStringString(&c.EvictionMinimumReclaim), "eviction-minimum-reclaim", "A set of minimum reclaims (e.g. imagefs.available=2Gi) that describes the minimum amount of resource the kubelet will reclaim when performing a pod eviction if that resource is under pressure.")
 	fs.Int32Var(&c.PodsPerCore, "pods-per-core", c.PodsPerCore, "Number of Pods per core that can run on this Kubelet. The total number of Pods on this Kubelet cannot exceed max-pods, so max-pods will be used if this calculation results in a larger number of Pods allowed on the Kubelet. A value of 0 disables this limit.")
 	fs.BoolVar(&c.ProtectKernelDefaults, "protect-kernel-defaults", c.ProtectKernelDefaults, "Default kubelet behaviour for kernel tuning. If set, kubelet errors if any of kernel tunables is different than kubelet defaults.")
+	fs.StringVar(&c.HostPortsReservation, "hostports-reservation", c.HostPortsReservation, "A map of host ports reserved for the kubelet to allocate dynamically, e.g. 'BE:21000-22000,AF1:11000-12000,AF4:9000-10000'.")
 
 	// Node Allocatable Flags
 	fs.Var(flag.NewMapStringString(&c.SystemReserved), "system-reserved", "A set of ResourceName=ResourceQuantity (e.g. cpu=200m,memory=500Mi,ephemeral-storage=1Gi) pairs that describe resources reserved for non-kubernetes components. Currently only cpu and memory are supported. See http://kubernetes.io/docs/user-guide/compute-resources for more detail. [default=none]")

--- a/pkg/kubelet/apis/kubeletconfig/helpers_test.go
+++ b/pkg/kubelet/apis/kubeletconfig/helpers_test.go
@@ -179,6 +179,7 @@ var (
 		"HostIPCSources[*]",
 		"HostNetworkSources[*]",
 		"HostPIDSources[*]",
+		"HostPortsReservation",
 		"IPTablesDropBit",
 		"IPTablesMasqueradeBit",
 		"ImageGCHighThresholdPercent",

--- a/pkg/kubelet/apis/kubeletconfig/types.go
+++ b/pkg/kubelet/apis/kubeletconfig/types.go
@@ -264,6 +264,8 @@ type KubeletConfiguration struct {
 	FeatureGates map[string]bool
 	// Tells the Kubelet to fail to start if swap is enabled on the node.
 	FailSwapOn bool
+	// Tells the Kubelet the host ports reserved for allocation dynamically.
+	HostPortsReservation string
 
 	/* following flags are meant for Node Allocatable */
 

--- a/pkg/kubelet/apis/kubeletconfig/v1alpha1/types.go
+++ b/pkg/kubelet/apis/kubeletconfig/v1alpha1/types.go
@@ -259,6 +259,8 @@ type KubeletConfiguration struct {
 	FeatureGates map[string]bool `json:"featureGates,omitempty"`
 	// Tells the Kubelet to fail to start if swap is enabled on the node.
 	FailSwapOn bool `json:"failSwapOn,omitempty"`
+	// Tells the Kubelet the host ports reserved for allocation dynamically.
+	HostPortsReservation string `json:"hostPortsReservation,omitempty"`
 
 	/* following flags are meant for Node Allocatable */
 

--- a/pkg/kubelet/apis/kubeletconfig/v1alpha1/zz_generated.conversion.go
+++ b/pkg/kubelet/apis/kubeletconfig/v1alpha1/zz_generated.conversion.go
@@ -251,6 +251,7 @@ func autoConvert_v1alpha1_KubeletConfiguration_To_kubeletconfig_KubeletConfigura
 	}
 	out.FeatureGates = *(*map[string]bool)(unsafe.Pointer(&in.FeatureGates))
 	out.FailSwapOn = in.FailSwapOn
+	out.HostPortsReservation = in.HostPortsReservation
 	out.SystemReserved = *(*map[string]string)(unsafe.Pointer(&in.SystemReserved))
 	out.KubeReserved = *(*map[string]string)(unsafe.Pointer(&in.KubeReserved))
 	out.SystemReservedCgroup = in.SystemReservedCgroup
@@ -376,6 +377,7 @@ func autoConvert_kubeletconfig_KubeletConfiguration_To_v1alpha1_KubeletConfigura
 	}
 	out.FeatureGates = *(*map[string]bool)(unsafe.Pointer(&in.FeatureGates))
 	out.FailSwapOn = in.FailSwapOn
+	out.HostPortsReservation = in.HostPortsReservation
 	out.SystemReserved = *(*map[string]string)(unsafe.Pointer(&in.SystemReserved))
 	out.KubeReserved = *(*map[string]string)(unsafe.Pointer(&in.KubeReserved))
 	out.SystemReservedCgroup = in.SystemReservedCgroup

--- a/pkg/kubelet/container/testing/fake_runtime_helper.go
+++ b/pkg/kubelet/container/testing/fake_runtime_helper.go
@@ -39,6 +39,9 @@ func (f *FakeRuntimeHelper) GenerateRunContainerOptions(pod *v1.Pod, container *
 	if len(container.TerminationMessagePath) != 0 {
 		opts.PodContainerDir = f.PodContainerDir
 	}
+	for _, env := range(container.Env) {
+		opts.Envs = append(opts.Envs, kubecontainer.EnvVar{Name: env.Name, Value: env.Value})
+	}
 	return &opts, nil
 }
 

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -671,6 +671,11 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 			return nil, err
 		}
 		klet.runtimeService = runtimeService
+		// Use the default local port opener
+		hostPortAllocator := kuberuntime.NewHostPortAllocator(kubeCfg.HostPortsReservation, nil)
+		if hostPortAllocator == nil {
+			return nil, fmt.Errorf("Failed to create a host port allocator.")
+		}
 		runtime, err := kuberuntime.NewKubeGenericRuntimeManager(
 			kubecontainer.FilterEventRecorder(kubeDeps.Recorder),
 			klet.livenessManager,
@@ -690,6 +695,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 			imageService,
 			kubeDeps.ContainerManager.InternalContainerLifecycle(),
 			legacyLogProvider,
+			hostPortAllocator,
 		)
 		if err != nil {
 			return nil, err

--- a/pkg/kubelet/kuberuntime/fake_hostport_opener.go
+++ b/pkg/kubelet/kuberuntime/fake_hostport_opener.go
@@ -1,0 +1,47 @@
+package kuberuntime
+
+import (
+	"fmt"
+	"sync"
+	"k8s.io/api/core/v1"
+)
+
+type hostport struct {
+	port     int32
+	protocol v1.Protocol
+}
+
+type fakeSocket struct {
+	port     int32
+	protocol v1.Protocol
+	closed   bool
+}
+
+func (f *fakeSocket) Close() error {
+	if f.closed {
+		return fmt.Errorf("Socket %q.%s already closed!", f.port, f.protocol)
+	}
+	f.closed = true
+	return nil
+}
+
+func NewFakeSocketManager() *fakeSocketManager {
+	return &fakeSocketManager{mem: make(map[hostport]*fakeSocket)}
+}
+
+type fakeSocketManager struct {
+	sync.RWMutex
+	mem map[hostport]*fakeSocket
+}
+
+func (f *fakeSocketManager) openFakeSocket(port int32, protocol v1.Protocol) (closeable, error) {
+	hp := hostport{port: port, protocol: protocol}
+	f.Lock()
+	defer f.Unlock()
+	if socket, ok := f.mem[hp]; ok && !socket.closed {
+		return nil, fmt.Errorf("hostport is occupied")
+	}
+	fs := &fakeSocket{hp.port, hp.protocol, false}
+	f.mem[hp] = fs
+	return fs, nil
+}

--- a/pkg/kubelet/kuberuntime/fake_kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/fake_kuberuntime_manager.go
@@ -105,6 +105,7 @@ func NewFakeKubeRuntimeManager(runtimeService internalapi.RuntimeService, imageS
 		&fakeHTTP{},
 		kubeRuntimeManager,
 		kubeRuntimeManager)
+	kubeRuntimeManager.hostPortAllocator = NewHostPortAllocator("AF4:1025-1027,BE:20000-20002", NewFakeSocketManager().openFakeSocket)
 
 	return kubeRuntimeManager, nil
 }

--- a/pkg/kubelet/kuberuntime/hostport_allocator.go
+++ b/pkg/kubelet/kuberuntime/hostport_allocator.go
@@ -1,0 +1,285 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kuberuntime
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"sync"
+
+	"github.com/golang/glog"
+	"k8s.io/api/core/v1"
+	runtimeapi "k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+)
+
+type containerHostPortsState struct {
+	// Maps from the container id to the corresponding allocated container host ports.
+	hostPorts map[podContainerId]map[string]containerHostPort
+}
+
+func (containerState *containerHostPortsState) setHostPorts(containerId *podContainerId, hostPorts map[string]containerHostPort) {
+	containerState.hostPorts[*containerId] = hostPorts
+}
+
+func (containerState *containerHostPortsState) getAndDeleteHostPorts(containerId *podContainerId) map[string]containerHostPort {
+	if containerPorts, existed := containerState.hostPorts[*containerId]; existed {
+		delete(containerState.hostPorts, *containerId)
+		return containerPorts
+	}
+	return nil
+}
+
+type hostPortRangeKey struct {
+	tos NetTOS
+	proto v1.Protocol
+}
+
+// Encapsulates the host port allocation state in this node.
+type HostPortAllocator struct {
+	sync.RWMutex
+	// Maps from the network TOS and protocol to the corresponding port range.
+	hostPortRangeMap map[hostPortRangeKey]*cachedHostPortRange
+	// Maps from a container to its allocated host ports.
+	containerState *containerHostPortsState
+	// The function to open a local port to verify the port is not currently occupied.
+	portOpener hostportOpener
+}
+
+// Creates a host port allocator.
+func NewHostPortAllocator(portRangeSpec string, portOpener hostportOpener) *HostPortAllocator {
+	glog.Infof("[hostportmanager] creating new in-memory port state")
+	tosPortRangeSpecs := parseHostPortRangeSpecs(portRangeSpec)
+	hostPortAllocator := &HostPortAllocator{
+		hostPortRangeMap: make(map[hostPortRangeKey]*cachedHostPortRange),
+		containerState: &containerHostPortsState{hostPorts: make(map[podContainerId]map[string]containerHostPort)},
+		portOpener: portOpener,
+	}
+	if hostPortAllocator.portOpener == nil {
+		hostPortAllocator.portOpener = openLocalPort
+	}
+	tosPortRanges := hostPortAllocator.hostPortRangeMap
+	for tos, rangeSpec := range (tosPortRangeSpecs) {
+		tosPortRanges[hostPortRangeKey{tos: tos, proto: v1.ProtocolTCP}] = createCachedHostPortRange(rangeSpec.lowerPort, rangeSpec.upperPort)
+		tosPortRanges[hostPortRangeKey{tos: tos, proto: v1.ProtocolUDP}] = createCachedHostPortRange(rangeSpec.lowerPort, rangeSpec.upperPort)
+	}
+	// TODO(wensheng): check or overwrite the sysctl directives to reserve the ports.
+	return hostPortAllocator
+}
+
+// Returns whether the host port allocation is enabled.
+func (hostPortAllocator *HostPortAllocator) isEnabled() bool {
+	return hostPortAllocator != nil && len(hostPortAllocator.hostPortRangeMap) > 0
+}
+
+// Initializes the HostPortAllocator from the current running kubernetes containers.
+// This should only be called when the kubelet is started at the beginning.
+func (hostPortAllocator *HostPortAllocator) Init(runningContainers []*runtimeapi.Container) error {
+	if !hostPortAllocator.isEnabled() {
+		return nil
+	}
+
+	glog.Infof("[hostportmanager] initializing new in-memory port state")
+	// Maps from host port range to the already allocated ports.
+	allocatedPortsMap := make(map[hostPortRangeKey]map[int32]bool)
+	for _, container := range runningContainers {
+		if container == nil {
+			continue
+		}
+		if container.State != runtimeapi.ContainerState_CONTAINER_RUNNING && container.State != runtimeapi.ContainerState_CONTAINER_CREATED {
+			continue
+		}
+
+		allocatedHostPorts := make(map[string]containerHostPort)
+		if found, err := getJSONObjectFromLabel(container.GetAnnotations(), kAllocatedHostPortAnnotationLabel, &allocatedHostPorts); err != nil || !found {
+			if err != nil {
+				glog.Warningf("Failed to parse %q from annotations %q: %v", kAllocatedHostPortAnnotationLabel, container.GetAnnotations(), err)
+			}
+			continue
+		}
+		labeledContainerInfo := getContainerInfoFromLabels(container.GetLabels())
+		if labeledContainerInfo == nil {
+			glog.Warningf("Failed to parse the labels for container %q", container.Id)
+			continue
+		}
+
+		glog.V(1).Infof("Try to parse the host ports for running container %s", container.Id)
+		allHostPorts := make(map[string]containerHostPort)
+		for name, hostPort := range allocatedHostPorts {
+			if hostPort.Valid() {
+				glog.Infof("Add host port %s allocated for container %s", hostPort, container.Id)
+				allHostPorts[name] = hostPort
+				portRangeKey :=	hostPortRangeKey{
+					tos: hostPort.Tos,
+					proto: normalizePortProtocol(hostPort.Proto),
+				}
+				if _, ok := hostPortAllocator.hostPortRangeMap[portRangeKey]; ok {
+					if _, ok := allocatedPortsMap[portRangeKey]; !ok {
+						allocatedPortsMap[portRangeKey] = make(map[int32]bool)
+					}
+					allocatedPortsMap[portRangeKey][hostPort.Port] = true
+				}
+			}
+		}
+
+		if len(allHostPorts) > 0 {
+			hostPortAllocator.containerState.setHostPorts(&podContainerId{
+				namespace: labeledContainerInfo.PodNamespace,
+				podName: labeledContainerInfo.PodName,
+				containerName: labeledContainerInfo.ContainerName,
+			}, allHostPorts)
+		}
+	}
+
+	for portRangeKey, allocatedPorts := range(allocatedPortsMap) {
+		if len(allocatedPorts) >= 0 {
+			hostPortAllocator.hostPortRangeMap[portRangeKey].Initialize(allocatedPorts)
+		}
+	}
+
+	return nil
+}
+
+func (hostPortAllocator *HostPortAllocator) isPortAllocated(hostPort containerHostPort) bool {
+	if portRange, ok := hostPortAllocator.hostPortRangeMap[hostPortRangeKey{
+		tos: hostPort.Tos,
+		proto: normalizePortProtocol(hostPort.Proto),
+	}]; ok && portRange != nil {
+		return portRange.isAllocated(hostPort.Port)
+	}
+	return false
+}
+
+func (hostPortAllocator *HostPortAllocator) releasePort(hostPort containerHostPort, portCacheKey string) {
+	if portRange, ok := hostPortAllocator.hostPortRangeMap[hostPortRangeKey{
+		tos: hostPort.Tos,
+		proto: normalizePortProtocol(hostPort.Proto),
+	}]; ok && portRange != nil {
+		portRange.releasePort(hostPort.Port, portCacheKey)
+	}
+}
+
+func (hostPortAllocator *HostPortAllocator) allocatePort(tos NetTOS, proto v1.Protocol, portCacheKey string) int32 {
+	normalizedProto := normalizePortProtocol(proto)
+	if portRange, ok := hostPortAllocator.hostPortRangeMap[hostPortRangeKey{
+		tos: tos, proto: normalizedProto,
+	}]; ok && portRange != nil {
+		return portRange.getFreePort(hostPortAllocator.portOpener, normalizedProto, portCacheKey)
+	}
+	return -1
+}
+
+// Updates the container options given the allocated host ports for the container.
+// The container options are used to create the underlying containers in the host through CRI.
+func MaybeUpdateContainerOptions(allocatedHostPorts map[string]containerHostPort, containerName string, containerEnvs []kubecontainer.EnvVar) (string, string) {
+	if len(allocatedHostPorts) <= 0 || len(containerEnvs) <= 0 {
+		return "", ""
+	}
+
+	updated := false
+	// Update the Env Vars to indicate the allocated host ports.
+	for idx := range(containerEnvs) {
+		if allocatedHostPort, ok := allocatedHostPorts[containerEnvs[idx].Name]; ok {
+			if allocatedHostPort.Port > 0 {
+				updated = true
+				containerEnvs[idx].Value = strconv.Itoa(int(allocatedHostPort.Port))
+			}
+		}
+	}
+
+	// Update the container ports annotation so that it can be persisted across the kubelet restarts.
+	if updated {
+		rawHostPorts, err := json.Marshal(allocatedHostPorts)
+		if err != nil {
+			glog.Errorf("Unable to marshal allocated host ports for container %q: %v", containerName, err)
+		} else {
+			return kAllocatedHostPortAnnotationLabel, string(rawHostPorts)
+		}
+	}
+	return "", ""
+}
+
+// Try to allocate the host ports for the given pod container.
+func (hostPortAllocator *HostPortAllocator) AllocatePortsForContainer(pod *v1.Pod, container *v1.Container) (map[string]containerHostPort, error) {
+	// Only if the pod is using host network, the host port allocation is meaningful.
+	if !hostPortAllocator.isEnabled() || container == nil || pod == nil || !kubecontainer.IsHostNetworkPod(pod) {
+		return nil, nil
+	}
+
+	// Release the allocated ports for the container if any first.
+	hostPortAllocator.ReleasePortsForContainer(pod, container.Name)
+
+	fullContainerSpec := podContainerId{namespace: pod.Namespace, podName: pod.Name, containerName: container.Name}
+	allocatedHostPorts := make(map[string]containerHostPort)
+	hostPortAllocator.Lock()
+	defer hostPortAllocator.Unlock()
+	var allocationError error = nil
+	for _, env := range container.Env {
+		if hostPort := parseContainerHostPortFromEnv(&env); hostPort != nil && hostPort.Port == 0 {
+			if _, existed := allocatedHostPorts[env.Name]; existed {
+				glog.Warningf("Container %s has duplicate port name %s, deduping the host port allocation", container.Name, env.Name)
+				continue
+			}
+			portCacheKey := getContainerPortCacheKey(&fullContainerSpec, env.Name)
+			allocatedPort := hostPortAllocator.allocatePort(hostPort.Tos, hostPort.Proto, portCacheKey)
+			if (allocatedPort > 0) {
+				hostPort.Port = allocatedPort
+				glog.Infof("Allocates host port %s for container %s", hostPort, fullContainerSpec)
+			} else {
+				glog.Warningf("Failed to allocate host port %s for container %s", hostPort, fullContainerSpec)
+				allocationError = fmt.Errorf("Cannot allocate all the host ports for container %s", container.Name)
+				break
+			}
+			allocatedHostPorts[env.Name] = *hostPort
+		}
+	}
+	// If the allocation failed, revert the partially allocated ports.
+	if allocationError != nil {
+		// Release the already allocated ports.
+		for _, hostPort := range allocatedHostPorts {
+			glog.V(1).Infof("Deallocates the already allocated host port %s", hostPort)
+			hostPortAllocator.releasePort(hostPort, /*portCacheKey=*/"")
+		}
+		return nil, allocationError
+	}
+
+	if len(allocatedHostPorts) > 0 {
+		hostPortAllocator.containerState.setHostPorts(&fullContainerSpec, allocatedHostPorts)
+	}
+	// Copy the allocated host ports to avoid leaking the internal data structure.
+	allocationCopy := make(map[string]containerHostPort)
+	for key, value := range(allocatedHostPorts) {
+		allocationCopy[key] = value
+	}
+	return allocationCopy, nil
+}
+
+func (hostPortAllocator *HostPortAllocator) ReleasePortsForContainer(pod *v1.Pod, containerName string) error {
+	if !hostPortAllocator.isEnabled() || len(containerName) <= 0 || pod == nil || !kubecontainer.IsHostNetworkPod(pod) {
+		return nil
+	}
+	hostPortAllocator.Lock()
+	defer hostPortAllocator.Unlock()
+	fullContainerSpec := &podContainerId{namespace: pod.Namespace, podName:pod.Name, containerName: containerName}
+	allHostPorts := hostPortAllocator.containerState.getAndDeleteHostPorts(fullContainerSpec)
+	for name, hostPort := range allHostPorts {
+		glog.V(1).Infof("Deallocates the host port %s for container %v", hostPort, fullContainerSpec)
+		hostPortAllocator.releasePort(hostPort, getContainerPortCacheKey(fullContainerSpec, name))
+	}
+	return nil
+}

--- a/pkg/kubelet/kuberuntime/hostport_allocator_test.go
+++ b/pkg/kubelet/kuberuntime/hostport_allocator_test.go
@@ -1,0 +1,384 @@
+package kuberuntime
+
+import (
+	"github.com/stretchr/testify/assert"
+	"k8s.io/api/core/v1"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+	runtimeapi "k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	"fmt"
+	"k8s.io/kubernetes/pkg/kubelet/types"
+)
+
+func TestUpdatecontainerOptsWithAllocatedHostPorts(t *testing.T) {
+	opener := NewFakeSocketManager().openFakeSocket
+	hostPortAllocator := NewHostPortAllocator("AF4:1025-1200,BE:20000-21000", opener)
+	hostPortAllocator.Init(nil)
+	containerName := "container1"
+
+	t.Run("ContainerPorts=0", func(t *testing.T) {
+		hostPortsAllocation := map[string]containerHostPort{
+			"PORTALLOC_TCP_port3": containerHostPort{Port: 1025},
+			"PORTALLOC_UDP_port4": containerHostPort{Port: 20500, Proto: "UDP"},
+			"PORTALLOC_unknown": containerHostPort{Port: 20001},
+		}
+		annotationKey, annotationValue := MaybeUpdateContainerOptions(hostPortsAllocation, containerName, nil)
+		assert.Empty(t, annotationKey)
+		assert.Empty(t, annotationValue)
+	})
+
+	t.Run("ContainerPorts=3", func(t *testing.T) {
+		t.Run("Without ports allocated", func(t *testing.T) {
+			defaultContainerEnvs := []kubecontainer.EnvVar{
+				kubecontainer.EnvVar{Name: "PORTALLOC_TCP_port3", Value: "AF4"},
+				kubecontainer.EnvVar{Name: "PORTALLOC_UDP_port4", Value: "BE"},
+			}
+			updatedContainerEnvs := make([]kubecontainer.EnvVar, len(defaultContainerEnvs))
+			copy(updatedContainerEnvs, defaultContainerEnvs)
+			annotationKey, annotationValue := MaybeUpdateContainerOptions(nil, containerName, updatedContainerEnvs)
+			assert.Empty(t, annotationKey)
+			assert.Empty(t, annotationValue)
+			assert.Equal(t, defaultContainerEnvs, updatedContainerEnvs)
+		})
+		t.Run("With both ports allocated", func(t *testing.T) {
+			allocatedHostPorts := map[string]containerHostPort{
+				"PORTALLOC_TCP_port3": containerHostPort{Port: 1025},
+				"PORTALLOC_UDP_port4": containerHostPort{Port: 20500, Proto: "UDP"},
+				"PORTALLOC_unknown": containerHostPort{Port: 20001},
+			}
+			containerEnvs := []kubecontainer.EnvVar{
+				kubecontainer.EnvVar{Name: "test", Value: "1024"},
+				kubecontainer.EnvVar{Name: "PORTALLOC_TCP_port3", Value: "AF4"},
+				kubecontainer.EnvVar{Name: "PORTALLOC_UDP_port4", Value: "BE"},
+			}
+			annotationKey, annotationValue := MaybeUpdateContainerOptions(allocatedHostPorts, containerName, containerEnvs)
+			assert.Equal(t, kAllocatedHostPortAnnotationLabel, annotationKey)
+			assert.Equal(t, `{"PORTALLOC_TCP_port3":{"port":1025},"PORTALLOC_UDP_port4":{"port":20500,"proto":"UDP"},"PORTALLOC_unknown":{"port":20001}}`, annotationValue)
+			assert.Equal(t, []kubecontainer.EnvVar{
+				{Name: "test", Value: "1024"},
+				{Name: "PORTALLOC_TCP_port3", Value: "1025"},
+				{Name: "PORTALLOC_UDP_port4", Value: "20500"},
+			}, containerEnvs)
+		})
+		t.Run("With one port allocation failed", func(t *testing.T) {
+			allocatedHostPorts := map[string]containerHostPort{
+				"PORTALLOC_TCP_port3": containerHostPort{Port: 1025},
+				"PORTALLOC_UDP_port4": containerHostPort{Port: 0, Proto: "UDP"},
+			}
+			containerEnvs := []kubecontainer.EnvVar{
+				kubecontainer.EnvVar{Name: "test", Value: "1024"},
+				kubecontainer.EnvVar{Name: "PORTALLOC_TCP_port3", Value: "AF4"},
+				kubecontainer.EnvVar{Name: "PORTALLOC_UDP_port4", Value: "BE"},
+			}
+			annotationKey, annotationValue := MaybeUpdateContainerOptions(allocatedHostPorts, containerName, containerEnvs)
+			assert.Equal(t, kAllocatedHostPortAnnotationLabel, annotationKey)
+			assert.Equal(t, `{"PORTALLOC_TCP_port3":{"port":1025},"PORTALLOC_UDP_port4":{"proto":"UDP"}}`, annotationValue)
+			assert.Equal(t, []kubecontainer.EnvVar{
+				{Name: "test", Value: "1024"},
+				{Name: "PORTALLOC_TCP_port3", Value: "1025"},
+				{Name: "PORTALLOC_UDP_port4", Value: "BE"},
+			}, containerEnvs)
+		})
+	})
+}
+
+func TestInitHostPortAllocator(t *testing.T) {
+	opener := NewFakeSocketManager().openFakeSocket
+	t.Run("Without running containers", func(t *testing.T) {
+		hostPortAllocator := NewHostPortAllocator("AF4:1025-1027,BE:20000-20001", opener)
+		hostPortAllocator.Init(nil)
+		assert.Empty(t, hostPortAllocator.containerState.hostPorts)
+	})
+
+	portsAnnotation0 := `{"PORTALLOC_TCP_port3":{"port":1025},"PORTALLOC_UDP_port4":{"port":0,"proto":"UDP"},"PORTALLOC_unknown":{"port":20001}}`
+	portsAnnotation1 := `{"PORTALLOC_TCP_port3":{"proto": "TCP", "tos": 4, "port":1025},"PORTALLOC_UDP_port4":{"port":0,"proto":"UDP"}}`
+	portsAnnotation2 := `{"PORTALLOC_TCP_port3":{"proto": "TCP", "tos": 4, "port":1026},"PORTALLOC_UDP_port4":{"port":20000,"proto":"UDP"}}`
+	t.Run("With running containers", func(t *testing.T) {
+		hostPortAllocator := NewHostPortAllocator("AF4:1025-1027,BE:20000-20001", opener)
+		hostPortAllocator.Init([]*runtimeapi.Container{
+			// Container which is not running.
+			&runtimeapi.Container{
+				Id: "Container0",
+				State: runtimeapi.ContainerState_CONTAINER_EXITED,
+				Annotations: map[string]string{kAllocatedHostPortAnnotationLabel: portsAnnotation1},
+				Labels: map[string]string{types.KubernetesContainerNameLabel: "Container0"},
+			},
+			&runtimeapi.Container{
+				Id: "Container1",
+				State: runtimeapi.ContainerState_CONTAINER_RUNNING,
+				Annotations: map[string]string{kAllocatedHostPortAnnotationLabel: portsAnnotation0},
+				Labels: map[string]string{types.KubernetesContainerNameLabel: "Container1"},
+			},
+			&runtimeapi.Container{
+				Id: "Container2",
+				State: runtimeapi.ContainerState_CONTAINER_CREATED,
+				Annotations: map[string]string{kAllocatedHostPortAnnotationLabel: portsAnnotation1},
+				Labels: map[string]string{types.KubernetesContainerNameLabel: "Container2"},
+			},
+			&runtimeapi.Container{
+				Id: "Container3",
+				State: runtimeapi.ContainerState_CONTAINER_RUNNING,
+				Annotations: map[string]string{kAllocatedHostPortAnnotationLabel: portsAnnotation2},
+				Labels: map[string]string{types.KubernetesContainerNameLabel: "Container3"},
+			},
+		})
+		assert.Equal(t, map[podContainerId]map[string]containerHostPort{
+			podContainerId{"", "", "Container2"}: map[string]containerHostPort{"PORTALLOC_TCP_port3": {Tos: NETTOS_AF4, Port: 1025, Proto: "TCP"}},
+			podContainerId{"", "", "Container3"}: map[string]containerHostPort{
+				"PORTALLOC_TCP_port3": {Tos: NETTOS_AF4, Port: 1026, Proto: "TCP"},
+				"PORTALLOC_UDP_port4": {Tos: NETTOS_BE, Port: 20000, Proto: "UDP"},
+			},
+		}, hostPortAllocator.containerState.hostPorts)
+		assert.True(t, hostPortAllocator.isPortAllocated(containerHostPort{Tos: NETTOS_AF4, Proto: v1.ProtocolTCP, Port: 1025}))
+		assert.False(t, hostPortAllocator.isPortAllocated(containerHostPort{Tos: NETTOS_AF4, Proto: v1.ProtocolUDP, Port: 1025}))
+		assert.True(t, hostPortAllocator.isPortAllocated(containerHostPort{Tos: NETTOS_BE, Proto: v1.ProtocolUDP, Port: 20000}))
+		assert.False(t, hostPortAllocator.isPortAllocated(containerHostPort{Tos: NETTOS_BE, Proto: v1.ProtocolTCP, Port: 20000}))
+		// Cannot allocate a new port because all the ports have been allocated.
+		portCacheKey := ""
+		assert.Equal(t, int32(-1), hostPortAllocator.allocatePort(NETTOS_AF4, "TCP", portCacheKey))
+		assert.Equal(t, int32(-1), hostPortAllocator.allocatePort(NETTOS_BE, "UDP", portCacheKey))
+		assert.Equal(t, int32(20000), hostPortAllocator.allocatePort(NETTOS_BE, "TCP", portCacheKey))
+	})
+}
+
+func TestAllocatePortsDirectly(t *testing.T) {
+	opener := NewFakeSocketManager().openFakeSocket
+	hostPortAllocator := NewHostPortAllocator("AF4:1025-1027,BE:20000-20001", opener)
+	assert := assert.New(t)
+	portCacheKey := ""
+	assert.Equal(int32(20000), hostPortAllocator.allocatePort(NETTOS_BE, "TCP", portCacheKey))
+	assert.Equal(int32(20000), hostPortAllocator.allocatePort(NETTOS_BE, "UDP", portCacheKey))
+	assert.Subset([]int32{
+		hostPortAllocator.allocatePort(NETTOS_AF4, "UDP", portCacheKey),
+		hostPortAllocator.allocatePort(NETTOS_AF4, "UDP", portCacheKey),
+	}, []int32{1025, 1026})
+	assert.Subset([]int32{
+		hostPortAllocator.allocatePort(NETTOS_AF4, "TCP", portCacheKey),
+		hostPortAllocator.allocatePort(NETTOS_AF4, "TCP", portCacheKey),
+	}, []int32{1025, 1026})
+	assert.Equal(int32(-1), hostPortAllocator.allocatePort(NETTOS_BE, "TCP", portCacheKey))
+	assert.Equal(int32(-1), hostPortAllocator.allocatePort(NETTOS_AF4, "UDP", portCacheKey))
+
+	// Try to release some ports.
+	hostPortAllocator.releasePort(containerHostPort{Tos: NETTOS_AF4, Port: 1026, Proto: "UDP"}, portCacheKey)
+	hostPortAllocator.releasePort(containerHostPort{Tos: NETTOS_AF4, Port: 1024, Proto: "TCP"}, portCacheKey)
+	hostPortAllocator.releasePort(containerHostPort{Tos: NETTOS_BE, Port: 20001, Proto: "TCP"}, portCacheKey)
+	hostPortAllocator.releasePort(containerHostPort{Tos: NETTOS_BE, Port: 20000, Proto: "UDP"}, portCacheKey)
+	// Allocate the ports again.
+	assert.Equal(int32(1026), hostPortAllocator.allocatePort(NETTOS_AF4, "UDP", portCacheKey))
+	assert.Equal(int32(-1), hostPortAllocator.allocatePort(NETTOS_AF4, "TCP", portCacheKey))
+	assert.Equal(int32(20000), hostPortAllocator.allocatePort(NETTOS_BE, "UDP", portCacheKey))
+	assert.Equal(int32(-1), hostPortAllocator.allocatePort(NETTOS_BE, "TCP", portCacheKey))
+}
+
+func TestAllocateAndFreePortsForContainers(t *testing.T) {
+	opener := NewFakeSocketManager().openFakeSocket
+	hostPortAllocator := NewHostPortAllocator("AF4:1025-1026,BE:20000-20001", opener)
+	assert := assert.New(t)
+	defaultEnvs := []v1.EnvVar{
+		{Name: "port1", Value: "1024"},
+		{Name: "PORTALLOC_TCP_port3", Value: "AF4"},
+		{Name: "PORTALLOC_UDP_port4", Value: "BE"},
+	}
+	t.Run("Do not allocate if not using host network", func(t *testing.T) {
+		pod := v1.Pod{
+			Spec: v1.PodSpec{
+				HostNetwork: false,
+				Containers: []v1.Container{
+					{Name: "Container0", Env: defaultEnvs},
+				},
+			},
+		}
+		allocationResult, err := hostPortAllocator.AllocatePortsForContainer(&pod, &pod.Spec.Containers[0])
+		assert.NoError(err)
+		assert.Empty(allocationResult)
+	})
+
+	t.Run("Do host port allocations", func(t *testing.T) {
+		expectedAllocatedPorts := map[string]containerHostPort{
+			"PORTALLOC_TCP_port3": containerHostPort{Tos: NETTOS_AF4, Port: 1025, Proto: "TCP"},
+			"PORTALLOC_UDP_port4": containerHostPort{Tos: NETTOS_BE, Port: 20000, Proto: "UDP"},
+		}
+		pod := v1.Pod{
+			Spec: v1.PodSpec{
+				HostNetwork: true,
+				Containers: []v1.Container{
+					{Name: "Container2", Env: defaultEnvs},
+				},
+			},
+		}
+		allocationResult, err := hostPortAllocator.AllocatePortsForContainer(&pod, &pod.Spec.Containers[0])
+		assert.NoError(err)
+		assert.Equal(expectedAllocatedPorts, allocationResult)
+		t.Run("Allocation result committed", func(t *testing.T) {
+			// Cannot allocate the port for new container, as all the ports have been taken.
+			newPod := pod
+			newPod.Name = "NewPod"
+			_, err := hostPortAllocator.AllocatePortsForContainer(&newPod, &newPod.Spec.Containers[0])
+			assert.Error(err)
+
+			hostPortAllocator.ReleasePortsForContainer(&pod, pod.Spec.Containers[0].Name)
+			// Now can allocate the ports again after they have been released.
+			allocationResult2, err2 := hostPortAllocator.AllocatePortsForContainer(&newPod, &newPod.Spec.Containers[0])
+			assert.NoError(err2)
+			assert.Equal(expectedAllocatedPorts, allocationResult2)
+			hostPortAllocator.ReleasePortsForContainer(&pod, pod.Spec.Containers[0].Name)
+		})
+		t.Run("Allocation result released", func(t *testing.T) {
+			hostPortAllocator.ReleasePortsForContainer(&pod, pod.Spec.Containers[0].Name)
+			// Can allocate the same set of ports
+			newPod := pod
+			newPod.Name = "NewPod"
+			allocationResult2, err2 := hostPortAllocator.AllocatePortsForContainer(&newPod, &newPod.Spec.Containers[0])
+			assert.NoError(err2)
+			assert.Equal(expectedAllocatedPorts, allocationResult2)
+		})
+	})
+}
+
+func TestAllocateAndReleaseInParallel(t *testing.T) {
+	t.Parallel()
+
+	opener := NewFakeSocketManager().openFakeSocket
+	hostPortAllocator := NewHostPortAllocator("AF4:1025-1100,BE:20000-20500", opener)
+	assert := assert.New(t)
+	defaultEnvs := []v1.EnvVar{
+		{Name: "port1", Value: "1024"},
+		{Name: "PORTALLOC_TCP_port3", Value: "AF4"},
+		{Name: "PORTALLOC_UDP_port4", Value: "BE"},
+	}
+
+	runTimes := 256
+	wg := sync.WaitGroup{}
+	wg.Add(runTimes)
+	for i := 0; i < runTimes; i += 1 {
+		containerName := fmt.Sprintf("Container-%d", i)
+		go func() {
+			defer wg.Done()
+			time.Sleep(time.Duration(rand.Intn(50)) * time.Millisecond)
+			pod := v1.Pod{
+				Spec: v1.PodSpec{
+					HostNetwork: true,
+					Containers: []v1.Container{
+						{Name: containerName, Env: defaultEnvs},
+					},
+				},
+			}
+			for {
+				allocationResult, err := hostPortAllocator.AllocatePortsForContainer(&pod, &pod.Spec.Containers[0])
+				if err == nil {
+					assert.Equal(2, len(allocationResult))
+					for _, port := range allocationResult{
+						if port.Proto == "UDP" {
+							assert.Equal(NETTOS_BE, port.Tos)
+							assert.True(port.Port >= 20000)
+							assert.True(port.Port < 20500)
+						} else {
+							assert.Equal(NETTOS_AF4, port.Tos)
+							assert.True(port.Port >= 1025)
+							assert.True(port.Port < 1100)
+						}
+					}
+					break
+				}
+				hostPortAllocator.ReleasePortsForContainer(&pod, pod.Spec.Containers[0].Name)
+				time.Sleep(time.Duration(rand.Intn(20)) * time.Millisecond)
+			}
+			time.Sleep(time.Duration(rand.Intn(200)) * time.Millisecond)
+			hostPortAllocator.ReleasePortsForContainer(&pod, pod.Spec.Containers[0].Name)
+		}()
+	}
+	wg.Wait()
+	assert.Empty(hostPortAllocator.containerState.hostPorts)
+}
+
+func TestAllocateTwiceForTheSameContainer(t *testing.T) {
+	t.Parallel()
+
+	opener := NewFakeSocketManager().openFakeSocket
+	hostPortAllocator := NewHostPortAllocator("AF4:1025-1027,BE:20000-20002", opener)
+	assert := assert.New(t)
+	defaultEnvs := []v1.EnvVar{
+		{Name: "port1", Value: "1024"},
+		{Name: "PORTALLOC_TCP_port3", Value: "AF4"},
+		{Name: "PORTALLOC_UDP_port4", Value: "BE"},
+	}
+	pod := v1.Pod{
+		Spec: v1.PodSpec{
+			HostNetwork: true,
+			Containers: []v1.Container{
+				{Name: "Container0", Env: defaultEnvs},
+			},
+		},
+	}
+	allocationResult, err := hostPortAllocator.AllocatePortsForContainer(&pod, &pod.Spec.Containers[0])
+	assert.NoError(err)
+
+	// Try to allocate for new container
+	newPod := pod
+	newPod.Name = "NewPod"
+	// Should allocate a new set of ports
+	allocationResult2, err2 := hostPortAllocator.AllocatePortsForContainer(&newPod, &newPod.Spec.Containers[0])
+	assert.NoError(err2)
+	assert.NotEqual(allocationResult, allocationResult2)
+
+	{
+		// We can still allocate the ports.
+		allocationResult3, err3 := hostPortAllocator.AllocatePortsForContainer(&pod, &pod.Spec.Containers[0])
+		assert.NoError(err3)
+		assert.Equal(allocationResult, allocationResult3)
+	}
+
+	{
+		// We can still allocate the ports after the previous allocated ports have been explicitly released.
+		allocationResult3, err3 := hostPortAllocator.AllocatePortsForContainer(&pod, &pod.Spec.Containers[0])
+		assert.NoError(err3)
+		assert.Equal(allocationResult, allocationResult3)
+	}
+}
+
+func TestAllocatedHostPortsStickToContainer(t *testing.T) {
+	t.Parallel()
+
+	opener := NewFakeSocketManager().openFakeSocket
+	hostPortAllocator := NewHostPortAllocator("AF4:1025-1027,BE:20000-20002", opener)
+	assert := assert.New(t)
+	defaultEnvs := []v1.EnvVar{
+		{Name: "port1", Value: "1024"},
+		{Name: "PORTALLOC_TCP_port3", Value: "AF4"},
+		{Name: "PORTALLOC_UDP_port4", Value: "BE"},
+	}
+	pod1 := v1.Pod{
+		Spec: v1.PodSpec{
+			HostNetwork: true,
+			Containers: []v1.Container{
+				{Name: "Container0", Env: defaultEnvs},
+			},
+		},
+	}
+	pod2 := pod1
+	pod1.Name = "pod1"
+	pod2.Name = "pod2"
+
+	allocationResult1, err1 := hostPortAllocator.AllocatePortsForContainer(&pod1, &pod1.Spec.Containers[0])
+	assert.NoError(err1)
+
+	allocationResult2, err2 := hostPortAllocator.AllocatePortsForContainer(&pod2, &pod2.Spec.Containers[0])
+	assert.NoError(err2)
+
+	hostPortAllocator.ReleasePortsForContainer(&pod1, pod1.Spec.Containers[0].Name)
+	hostPortAllocator.ReleasePortsForContainer(&pod2, pod2.Spec.Containers[0].Name)
+
+	// With caching, pod2 will be allocated with the previous ports allocated to pod2, even it's allocated first.
+	allocationResult22, err22 := hostPortAllocator.AllocatePortsForContainer(&pod2, &pod2.Spec.Containers[0])
+	assert.NoError(err22)
+
+	allocationResult12, err12 := hostPortAllocator.AllocatePortsForContainer(&pod1, &pod1.Spec.Containers[0])
+	assert.NoError(err12)
+
+	assert.Equal(allocationResult1, allocationResult12)
+	assert.Equal(allocationResult2, allocationResult22)
+}

--- a/pkg/kubelet/kuberuntime/hostport_allocator_utils.go
+++ b/pkg/kubelet/kuberuntime/hostport_allocator_utils.go
@@ -1,0 +1,151 @@
+package kuberuntime
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/golang/glog"
+	"k8s.io/api/core/v1"
+)
+
+type NetTOS int32
+
+// Defines different level of network type of service:
+// NETTOS_BE: best effort
+// NETTOS_AF1: assured forwarding level 1
+// NETTOS_AF4: assured forwarding level 4
+// Traffic with higher level TOS will be served better in network
+const (
+	NETTOS_INVALID NetTOS = -1
+	NETTOS_BE NetTOS = 0
+	NETTOS_AF1 NetTOS = 1
+	NETTOS_AF4 NetTOS = 4
+)
+
+const (
+	kAllocatedHostPortNamePrefix string = "PORTALLOC_"
+	kAllocatedHostPortAnnotationLabel = "io.kubernetes.container.allocated_host_ports"
+	kMaxHostPortNumber int32 = 65536
+)
+
+// Encapsulates the fields to represent a container host port.
+type containerHostPort struct {
+	Port  int32 `json:"port,omitempty"`
+	Tos   NetTOS `json:"tos,omitempty"`
+	Proto v1.Protocol `json:"proto,omitempty"`
+}
+
+func (hostPort containerHostPort) String() string {
+	return fmt.Sprintf("(port: %v, TOS: %v, proto: %v)", hostPort.Port, hostPort.Tos, hostPort.Proto)
+}
+
+// Returns whether the specific container host port is valid.
+func (hostPort containerHostPort) Valid() bool {
+	return hostPort.Port > 0 && hostPort.Port < kMaxHostPortNumber &&
+		hostPort.Tos >= NETTOS_BE && hostPort.Tos <= NETTOS_AF4 &&
+		(hostPort.Proto == v1.ProtocolTCP || hostPort.Proto == v1.ProtocolUDP)
+}
+
+// Returns the normalized port protocol, specifically empty protocol is default to TCP.
+func normalizePortProtocol(inputProto v1.Protocol) v1.Protocol {
+	if inputProto == "" {
+		return v1.ProtocolTCP
+	}
+	return inputProto
+}
+
+// Parse the NetTOS from the corresponding string representation.
+func parseNetTOS(tosName string, defaultTOS NetTOS) NetTOS {
+	switch tosName {
+	case "BE":
+		return NETTOS_BE
+	case "AF1":
+		return NETTOS_AF1
+	case "AF4":
+		return NETTOS_AF4
+	default:
+		return defaultTOS
+	}
+}
+
+// Given an EnvVar for a container, if it refers to a host port allocation, parse the corresponding containerHostPort
+// struct from the EnvVar's name and value. Returns nil if the EnvVar is not for host port allocation.
+func parseContainerHostPortFromEnv(containerEnv *v1.EnvVar) *containerHostPort {
+	if !strings.HasPrefix(containerEnv.Name, kAllocatedHostPortNamePrefix) {
+		return nil
+	}
+	portName := strings.TrimPrefix(containerEnv.Name, kAllocatedHostPortNamePrefix)
+	portProto := v1.ProtocolTCP
+	if strings.HasPrefix(portName, "UDP_") {
+		portProto = v1.ProtocolUDP
+	} else if !strings.HasPrefix(portName, "TCP_") {
+		return nil
+	}
+	portTOS := parseNetTOS(containerEnv.Value, NETTOS_INVALID)
+	if portTOS == NETTOS_INVALID {
+		return nil
+	}
+	return &containerHostPort{Port: 0, Tos: portTOS, Proto: portProto}
+}
+
+// Specify a range of host ports reservation [lowerPort, upperPort)
+type hostPortRangeSpec struct {
+	lowerPort int32
+	upperPort int32
+}
+
+// Parses a port range specification like: <ToS>:<lower_port>-<upper_port>.
+func parseOnePortRangeSpecField(field string) (NetTOS, int32, int32) {
+	if tosPortRangeFields := strings.Split(field, ":"); len(tosPortRangeFields) == 2 {
+		if portTOS := parseNetTOS(tosPortRangeFields[0], NETTOS_INVALID); portTOS != NETTOS_INVALID {
+			if portFields := strings.Split(tosPortRangeFields[1], "-"); len(portFields) == 2 {
+				if lower, err := strconv.Atoi(portFields[0]); err == nil {
+					if upper, err := strconv.Atoi(portFields[1]); err == nil {
+						return portTOS, int32(lower), int32(upper)
+					}
+				}
+			}
+		}
+	}
+	return NETTOS_INVALID, -1, -1
+}
+
+// Parses host port range specification from the given |portRangeSpec| string.
+// A valid |portRangeSpec| has the format: "<ToS1>:<lower_port1>-<upper_port1>,...<ToSN>:<lower_portN>-<upper_portN>".
+func parseHostPortRangeSpecs(portRangeSpec string) map[NetTOS]hostPortRangeSpec {
+	const (
+		kMinValidPort int32 = 1025
+		kMaxValidPort int32 = 32768
+	)
+	spec_fields := strings.Split(portRangeSpec, ",")
+	portRangeSpecMap := make(map[NetTOS]hostPortRangeSpec)
+	for _, field := range spec_fields {
+		portTOS, lower, upper := parseOnePortRangeSpecField(field)
+		if portTOS == NETTOS_INVALID || lower < kMinValidPort || upper > kMaxValidPort || lower > upper {
+			glog.Warningf("Skip invalid host port range spec: %q", field)
+			continue
+		}
+		if _, ok := portRangeSpecMap[portTOS]; ok {
+			glog.Warningf("Duplicate port range spec for TOS %v", portTOS)
+			continue
+		}
+		portRangeSpecMap[portTOS] = hostPortRangeSpec{lowerPort: lower, upperPort: upper}
+	}
+	return portRangeSpecMap
+}
+
+// The data struct should uniquely identify a container in a pod.
+type podContainerId struct {
+	namespace string
+	podName string
+	containerName string
+}
+
+func (containerId podContainerId) String() string {
+	return fmt.Sprintf("%s.%s.%s", containerId.namespace, containerId.podName, containerId.containerName)
+}
+
+func getContainerPortCacheKey(containerId *podContainerId, portName string) string {
+	return fmt.Sprintf("%s.%s", containerId, portName)
+}

--- a/pkg/kubelet/kuberuntime/hostport_allocator_utils_test.go
+++ b/pkg/kubelet/kuberuntime/hostport_allocator_utils_test.go
@@ -1,0 +1,123 @@
+package kuberuntime
+
+import (
+	"github.com/stretchr/testify/assert"
+	"k8s.io/api/core/v1"
+	"testing"
+)
+
+func TestNormalizeProtocol(t *testing.T) {
+	assert.Equal(t, v1.ProtocolTCP, normalizePortProtocol(v1.ProtocolTCP))
+	assert.Equal(t, v1.ProtocolUDP, normalizePortProtocol(v1.ProtocolUDP))
+	assert.Equal(t, v1.ProtocolTCP, normalizePortProtocol(""))
+}
+
+func TestParseNetTOS(t *testing.T) {
+	assert.Equal(t, NETTOS_INVALID, parseNetTOS("UNKNOWN", NETTOS_INVALID))
+	assert.Equal(t, NETTOS_BE, parseNetTOS("UNKNOWN", NETTOS_BE))
+	assert.Equal(t, NETTOS_BE, parseNetTOS("BE", NETTOS_INVALID))
+	assert.Equal(t, NETTOS_AF1, parseNetTOS("AF1", NETTOS_BE))
+	assert.Equal(t, NETTOS_AF4, parseNetTOS("AF4", NETTOS_BE))
+}
+
+func TestParseContainerHostPort(t *testing.T) {
+	testCases := []struct {
+		env        v1.EnvVar
+		outputPort *containerHostPort
+	}{
+		{
+			env: v1.EnvVar{
+				Name: "unknown",
+				Value: "AF4",
+			},
+			outputPort: nil,
+		},
+		{
+			env: v1.EnvVar{
+				Name: "PORTALLOC_TCP_port1",
+				Value: "unknown",
+			},
+			outputPort: nil,
+		},
+		{
+			env: v1.EnvVar{
+				Name: "PORTALLOC_UNK_port1",
+				Value: "BE",
+			},
+			outputPort: nil,
+		},
+		{
+			env: v1.EnvVar{
+				Name: "PORTALLOC_UDP_port1",
+				Value: "AF4",
+			},
+			outputPort: &containerHostPort{
+				Port: 0,
+				Tos: NETTOS_AF4,
+				Proto: "UDP",
+			},
+		},
+		{
+			env: v1.EnvVar{
+				Name: "PORTALLOC_TCP_important",
+				Value: "AF4",
+			},
+			outputPort: &containerHostPort{
+				Port: 0,
+				Tos: NETTOS_AF4,
+				Proto: "TCP",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		hostPort := parseContainerHostPortFromEnv(&tc.env)
+		if tc.outputPort == nil {
+			assert.Nil(t, hostPort)
+		} else {
+			assert.Equal(t, *tc.outputPort, *hostPort)
+		}
+	}
+}
+
+func TestParseHostPortRangeSpecs(t *testing.T) {
+	testCases := []struct {
+		spec           string
+		portRangeSpecs map[NetTOS]hostPortRangeSpec
+	}{
+		{
+			spec: "",
+			portRangeSpecs: map[NetTOS]hostPortRangeSpec{},
+		},
+		{
+			spec: "AF4:1025-1200,BE:20000-21000",
+			portRangeSpecs: map[NetTOS]hostPortRangeSpec{
+				NETTOS_AF4: hostPortRangeSpec{1025, 1200},
+				NETTOS_BE: hostPortRangeSpec{20000, 21000},
+			},
+		},
+		{
+			spec: "AF4:1025-1024,BE:20000-21000",
+			portRangeSpecs: map[NetTOS]hostPortRangeSpec{
+				NETTOS_BE: hostPortRangeSpec{20000, 21000},
+			},
+		},
+		{
+			spec: "AF4:1025-1028f,BE:20000-21000",
+			portRangeSpecs: map[NetTOS]hostPortRangeSpec{
+				NETTOS_BE: hostPortRangeSpec{20000, 21000},
+			},
+		},
+		{
+			spec: "UNKNOWN:1025-1028,,BE:20000-21000",
+			portRangeSpecs: map[NetTOS]hostPortRangeSpec{
+				NETTOS_BE: hostPortRangeSpec{20000, 21000},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		portRangeSpecs := parseHostPortRangeSpecs(tc.spec)
+		assert.Equal(t, tc.portRangeSpecs, portRangeSpecs)
+	}
+}

--- a/pkg/kubelet/kuberuntime/hostport_range.go
+++ b/pkg/kubelet/kuberuntime/hostport_range.go
@@ -1,0 +1,243 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kuberuntime
+
+import (
+	"fmt"
+	"net"
+	"sync"
+
+	"container/list"
+	"github.com/golang/glog"
+	"k8s.io/api/core/v1"
+	"hash/fnv"
+)
+
+type hostportOpener func(int32, v1.Protocol) (closeable, error)
+
+type closeable interface {
+	Close() error
+}
+
+func openLocalPort(port int32, proto v1.Protocol) (closeable, error) {
+	// NOTE: We should not need to have a real listen()ing socket - bind()
+	// should be enough, but I can't figure out a way to e2e test without
+	// it.  Tools like 'ss' and 'netstat' do not show sockets that are
+	// bind()ed but not listen()ed, and at least the default debian netcat
+	// has no way to avoid about 10 seconds of retries.
+	switch proto {
+	case v1.ProtocolTCP:
+		listener, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+		if err != nil {
+			return nil, err
+		}
+		glog.V(3).Infof("Opened local port %v for TCP.", port)
+		return listener, nil
+	case v1.ProtocolUDP:
+		addr, err := net.ResolveUDPAddr("udp", fmt.Sprintf(":%d", port))
+		if err != nil {
+			return nil, err
+		}
+		conn, err := net.ListenUDP("udp", addr)
+		if err != nil {
+			return nil, err
+		}
+		glog.V(3).Infof("Opened local port %v for UDP.", port)
+		return conn, nil
+	default:
+		return nil, fmt.Errorf("unknown protocol %v", proto)
+	}
+}
+
+// Represents and manages a range of hosts ports that can be allocated.
+type lruPortEntry struct {
+	keyHash uint32
+	port int32
+}
+
+type cachedHostPortRange struct {
+	sync.RWMutex
+	// The lowest port in the range.
+	lowerPort       int32
+	// Indicates whether a port in the range has been allocated. It has to be consistent with lruEntries.
+	// This field is used to make sure the same port is not released multiple times.
+	ports_allocated []bool
+	// Maintains a LRU list of free ports in the range. The port at the front is released earlier, compared to the
+	// port at the back, thus the front port should be allocated at first. The list should be consistent with ports_allocated field.
+	lruEntries      *list.List
+	// Maintains a port allocation cache to provide port stickiness.
+	cache           map[uint32]*list.Element
+}
+
+func (pr *cachedHostPortRange) inRange(port int32) bool {
+	return port >= pr.lowerPort && port < pr.lowerPort + int32(len(pr.ports_allocated))
+}
+
+// Returns the index corresponding to the given |port|.
+func (pr *cachedHostPortRange) getPortIndex(port int32) int {
+	if pr.inRange(port) {
+		return int(port - pr.lowerPort)
+	}
+	return -1
+}
+
+func getCacheKeyHash(cacheKey string) uint32 {
+	hasher := fnv.New32a()
+	hasher.Write([]byte(cacheKey))
+	return hasher.Sum32()
+}
+
+// Requires lowerPort <= upperPort
+func createCachedHostPortRange(lowerPort int32, upperPort int32) *cachedHostPortRange {
+	if upperPort < lowerPort {
+		upperPort = lowerPort
+	}
+
+	pr := &cachedHostPortRange{
+		lowerPort: lowerPort,
+		ports_allocated: make([]bool, upperPort - lowerPort),
+	}
+	pr.Initialize(nil)
+	return pr
+}
+
+// Initialize the host port range given the already allocated ports.
+func (pr *cachedHostPortRange) Initialize(allocatedPorts map[int32]bool) {
+	pr.lruEntries = list.New()
+	pr.cache = make(map[uint32]*list.Element)
+	for index := len(pr.ports_allocated) - 1; index >= 0; index-- {
+		// By default, treats all the ports have been allocated.
+		pr.ports_allocated[index] = true
+		port := int32(index) + pr.lowerPort
+		// Release the port if it turns out not being allocated yet.
+		if _, ok := allocatedPorts[port]; !ok {
+			pr.releasePort(port, "")
+		}
+	}
+}
+
+// Test whether a given |port| has been allocated in the host.
+func tryOpenPort(portOpener hostportOpener, port int32, proto v1.Protocol) bool {
+	sock, err := portOpener(port, proto)
+	if err == nil && sock != nil {
+		// Note that when the socket is closed, in theory another process may be able to take the
+		// allocated port at the worst case if the process binds to the port before the container
+		// does so. This will result in that the container can not be started, and eventually restarted
+		// by kubelet, which will allocate a new port for the container.
+		sock.Close()
+		return true
+	}
+	return false
+}
+
+func (pr *cachedHostPortRange) tryAllocatePortFromLRUEntry(portOpener hostportOpener, proto v1.Protocol, element *list.Element) int32 {
+	if element == nil {
+		return -1
+	}
+	if lruEntry, ok := element.Value.(*lruPortEntry); ok && pr.inRange(lruEntry.port) {
+		port := lruEntry.port
+		// Even if the port is already bound, it's still cleared from the cache, as the cached port is not valid.
+		// Here it makes sure that only when the cache entry matches with the entry in lruEntries, the cache entry is deleted.
+		if expectedElement, ok := pr.cache[lruEntry.keyHash]; ok && expectedElement == element {
+			delete(pr.cache, lruEntry.keyHash)
+			lruEntry.keyHash = 0
+		}
+		if tryOpenPort(portOpener, port, proto) {
+			// Needs to keep ports_allocated to be consistent with lruEntries.
+			if index := pr.getPortIndex(port); index >= 0 {
+				if pr.ports_allocated[index] {
+					glog.Errorf("Internal state mismatched for port %v", port)
+					return -1
+				}
+				pr.ports_allocated[index] = true
+			}
+			pr.lruEntries.Remove(element)
+			return port
+		}
+	}
+	return -1
+}
+
+// Returns a free host port within the predefined range and not bound yet. If no such free port is available, returns -1.
+// cacheKey is used to provide port allocation stickiness, i.e. a specific container is more likely to be allocated with
+// the port it just released.
+func (pr *cachedHostPortRange) getFreePort(portOpener hostportOpener, proto v1.Protocol, cacheKey string) int32 {
+	// We need to hold the mutex when searching for a free port in the pre-allocated range, to avoid the race condition
+	// when multiple pods try to allocate the port at the same time.
+	pr.Lock()
+	defer pr.Unlock()
+
+	// Try to get the port from the cache first.
+	if len(cacheKey) > 0 {
+		cacheKeyHash := getCacheKeyHash(cacheKey)
+		if element, ok := pr.cache[cacheKeyHash]; ok && element != nil {
+			if port := pr.tryAllocatePortFromLRUEntry(portOpener, proto, element); port > 0 {
+				return port
+			}
+		}
+	}
+	if pr.lruEntries.Len() <= 0 {
+		return -1
+	}
+	// Tries to get the port from the LRU entry list, from the front (least recently released) to the back.
+	for e := pr.lruEntries.Front(); e != nil; e = e.Next() {
+		if port := pr.tryAllocatePortFromLRUEntry(portOpener, proto, e); port > 0 {
+			// It's safe to remove e directly here as it returns immediately.
+			return port
+		}
+	}
+	// No available port
+	return -1
+}
+
+// Indicates that the given |port| is released. |cacheKey| provides the stickiness to the next allocation: the same container
+// is more likely to get this port at the next allocation.
+func (pr *cachedHostPortRange) releasePort(port int32, cacheKey string) {
+	index := pr.getPortIndex(port)
+	if index < 0 {
+		return
+	}
+	pr.Lock()
+	defer pr.Unlock()
+
+	if !pr.ports_allocated[index] {
+		glog.Warningf("Try to release an unallocated port: %v for %v", port, cacheKey)
+		return
+	}
+	// Need to ensure ports_allocated is consistent with lruEntries.
+	pr.ports_allocated[index] = false
+	if len(cacheKey) <= 0 {
+		// Bypass the cache
+		pr.lruEntries.PushFront(&lruPortEntry{port: port, keyHash: 0})
+		return
+	}
+	cacheKeyHash := getCacheKeyHash(cacheKey)
+	if element := pr.lruEntries.PushBack(&lruPortEntry{port: port, keyHash: cacheKeyHash}); element != nil {
+		pr.cache[cacheKeyHash] = element
+	}
+}
+
+// This method is for testing purpose only.
+func (pr *cachedHostPortRange) isAllocated(port int32) bool {
+	index := pr.getPortIndex(port)
+	if index < 0 {
+		return false
+	}
+	pr.Lock()
+	defer pr.Unlock()
+	return pr.ports_allocated[index]
+}

--- a/pkg/kubelet/kuberuntime/hostport_range_test.go
+++ b/pkg/kubelet/kuberuntime/hostport_range_test.go
@@ -1,0 +1,357 @@
+package kuberuntime
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/api/core/v1"
+	"math/rand"
+	"fmt"
+)
+
+func TestGetFreePorts(t *testing.T) {
+	opener := NewFakeSocketManager()
+	var upperPort int32 = 1028
+	var lowerPort int32 = 1025
+	hostPortRange := createCachedHostPortRange(lowerPort, upperPort)
+	testCases := []struct {
+		protocol  v1.Protocol
+		allocated bool
+	}{
+		{v1.ProtocolTCP, true},
+		{v1.ProtocolTCP, true},
+		{v1.ProtocolTCP, true},
+		{v1.ProtocolTCP, false},
+	}
+
+	for _, tc := range testCases {
+		port := hostPortRange.getFreePort(opener.openFakeSocket, tc.protocol, "")
+		if tc.allocated {
+			assert.True(t, port >= lowerPort && port < upperPort, "Allocated %d for %s", port, tc.protocol)
+		} else {
+			assert.True(t, port < 0)
+		}
+	}
+}
+
+func TestGetFreePortsInParallel(t *testing.T) {
+	opener := NewFakeSocketManager()
+	var upperPort int32 = 1200
+	var lowerPort int32 = 1025
+	hostPortRange := createCachedHostPortRange(lowerPort, upperPort)
+	allocatedPorts := struct {
+		sync.RWMutex
+		ports map[int32]int
+	}{
+		ports: make(map[int32]int),
+	}
+
+	runTimes := 256
+	wg := sync.WaitGroup{}
+	wg.Add(runTimes)
+	for i := 0; i < runTimes; i += 1 {
+		go func() {
+			defer wg.Done()
+			if port := hostPortRange.getFreePort(opener.openFakeSocket, v1.ProtocolTCP, ""); port > 0 {
+				assert.True(t, port >= lowerPort && port < upperPort)
+				allocatedPorts.Lock()
+				defer allocatedPorts.Unlock()
+				allocatedPorts.ports[port] += 1
+			}
+		}()
+	}
+	wg.Wait()
+	assert.Equal(t, int(upperPort - lowerPort), len(allocatedPorts.ports))
+	for _, times := range allocatedPorts.ports {
+		assert.Equal(t, 1, times)
+	}
+}
+
+func TestInvalidPortRange(t *testing.T) {
+	opener := NewFakeSocketManager().openFakeSocket
+	hostPortRange := createCachedHostPortRange(1025, 1024)
+	assert.True(t, hostPortRange.getFreePort(opener, v1.ProtocolTCP, "") < 0)
+}
+
+func TestHostPortNotPhysicallyReleased(t *testing.T) {
+	socketManager := NewFakeSocketManager()
+	opener := socketManager.openFakeSocket
+	var lowerPort int32 = 1024
+	cacheKey := ""
+	hostPortRange := createCachedHostPortRange(lowerPort, 1025)
+	allocatedPort := hostPortRange.getFreePort(opener, v1.ProtocolTCP, cacheKey)
+	assert.Equal(t, lowerPort, allocatedPort)
+	opener(allocatedPort, v1.ProtocolTCP)
+	// Although the port 1024 is released, it's still bound physically so cannot be allocated again.
+	hostPortRange.releasePort(lowerPort, cacheKey)
+	assert.True(t, hostPortRange.getFreePort(opener, v1.ProtocolTCP, cacheKey) < 0)
+	// Now unbinds the physical port
+	socketManager.mem[hostport{port: allocatedPort, protocol: v1.ProtocolTCP}].Close()
+	// Then the port can be allocated again.
+	assert.Equal(t, lowerPort, hostPortRange.getFreePort(opener, v1.ProtocolTCP, cacheKey))
+}
+
+func TestAllocateReleaseInParallel(t *testing.T) {
+	t.Parallel()
+	opener := NewFakeSocketManager().openFakeSocket
+	var upperPort int32 = 1200
+	var lowerPort int32 = 1025
+	hostPortRange := createCachedHostPortRange(lowerPort, upperPort)
+
+	runTimes := 256
+	wg := sync.WaitGroup{}
+	wg.Add(runTimes)
+	for i := 0; i < runTimes; i += 1 {
+		go func(index int) {
+			cacheKey := fmt.Sprintf("container-%d", index)
+			defer wg.Done()
+			time.Sleep(time.Duration(rand.Intn(20)) * time.Millisecond)
+			var port int32
+			for {
+				if port = hostPortRange.getFreePort(opener, v1.ProtocolTCP, cacheKey); port > 0 {
+					assert.True(t, port >= lowerPort && port < upperPort)
+					break
+				}
+				time.Sleep(time.Duration(rand.Intn(20)) * time.Millisecond)
+			}
+			time.Sleep(time.Duration(rand.Intn(20)) * time.Millisecond)
+			hostPortRange.releasePort(port, cacheKey)
+		}(i)
+	}
+	wg.Wait()
+
+	for port := lowerPort; port < upperPort; port += 1 {
+		assert.False(t, hostPortRange.isAllocated(port), "Port %d was not released", port)
+	}
+}
+
+func TestCachedHostPortNotPhysicallyReleased(t *testing.T) {
+	socketManager := NewFakeSocketManager()
+	opener := socketManager.openFakeSocket
+	var lowerPort int32 = 1024
+	portCacheKey := "cache"
+	hostPortRange := createCachedHostPortRange(lowerPort, 1025)
+	allocatedPort := hostPortRange.getFreePort(opener, v1.ProtocolTCP, portCacheKey)
+	opener(allocatedPort, v1.ProtocolTCP)
+	// Although the port 1024 is released, it's still bound physically so cannot be allocated again.
+	hostPortRange.releasePort(allocatedPort, portCacheKey)
+	assert.True(t, hostPortRange.getFreePort(opener, v1.ProtocolTCP, portCacheKey) < 0)
+	// The cached port should be released
+	assert.Empty(t, hostPortRange.cache)
+	assert.False(t, hostPortRange.isAllocated(lowerPort))
+	// Now unbinds the physical port
+	socketManager.mem[hostport{port: allocatedPort, protocol: v1.ProtocolTCP}].Close()
+	// Then the port can be allocated again.
+	assert.Equal(t, lowerPort, hostPortRange.getFreePort(opener, v1.ProtocolTCP, portCacheKey))
+	assert.True(t, hostPortRange.isAllocated(lowerPort))
+}
+
+func TestAllocatePortFromCache(t *testing.T) {
+	socketManager := NewFakeSocketManager()
+	opener := socketManager.openFakeSocket
+	var lowerPort int32 = 1024
+	portCacheKey := "cache"
+	portCacheKey2 := "cache2"
+
+	hostPortRange := createCachedHostPortRange(lowerPort, 1026)
+	allocatedPort := hostPortRange.getFreePort(opener, v1.ProtocolTCP, portCacheKey)
+	assert.True(t, allocatedPort >= lowerPort)
+	// Release the port which goes to the cache.
+	hostPortRange.releasePort(allocatedPort, portCacheKey)
+	// Allocate a new port which has different cache key and is allocated directly.
+	newAllocatedPort := hostPortRange.getFreePort(opener, v1.ProtocolTCP, portCacheKey2)
+	assert.True(t, newAllocatedPort >= lowerPort)
+	assert.NotEqual(t, allocatedPort, newAllocatedPort)
+	// Now reallocate a port with the same cache key
+	assert.False(t, hostPortRange.isAllocated(allocatedPort))
+	reallocatedPort := hostPortRange.getFreePort(opener, v1.ProtocolTCP, portCacheKey)
+	assert.Equal(t, allocatedPort, reallocatedPort)
+	assert.True(t, hostPortRange.isAllocated(allocatedPort))
+}
+
+func TestAllocatePortFromOtherCacheEntry(t *testing.T) {
+	socketManager := NewFakeSocketManager()
+	opener := socketManager.openFakeSocket
+	var lowerPort int32 = 1024
+	portCacheKey := "cache"
+	portCacheKey2 := "cache2"
+
+	hostPortRange := createCachedHostPortRange(lowerPort, 1026)
+	allocatedPort := hostPortRange.getFreePort(opener, v1.ProtocolTCP, portCacheKey)
+	assert.True(t, allocatedPort >= lowerPort)
+	allocatedPort2 := hostPortRange.getFreePort(opener, v1.ProtocolTCP, portCacheKey2)
+	assert.True(t, allocatedPort2 >= lowerPort)
+	assert.NotEqual(t, allocatedPort, allocatedPort2)
+	// Release the port which goes to the cache.
+	hostPortRange.releasePort(allocatedPort, portCacheKey)
+	// Allocate a new port which should be from the cache entry portCacheKey
+	portCacheKey3 := "cache3"
+	assert.False(t, hostPortRange.isAllocated(allocatedPort))
+	allocatedPort3 := hostPortRange.getFreePort(opener, v1.ProtocolTCP, portCacheKey3)
+	assert.Equal(t, allocatedPort, allocatedPort3)
+	assert.True(t, hostPortRange.isAllocated(allocatedPort))
+}
+
+func TestFreePortWithWrongCacheKey(t *testing.T) {
+	socketManager := NewFakeSocketManager()
+	opener := socketManager.openFakeSocket
+	var lowerPort int32 = 1024
+	portCacheKey := "cache"
+	portCacheKey2 := "cache2"
+
+	hostPortRange := createCachedHostPortRange(lowerPort, 1026)
+	allocatedPort := hostPortRange.getFreePort(opener, v1.ProtocolTCP, portCacheKey)
+	assert.True(t, allocatedPort >= lowerPort)
+	allocatedPort2 := hostPortRange.getFreePort(opener, v1.ProtocolTCP, portCacheKey2)
+	assert.True(t, allocatedPort2 >= lowerPort)
+	assert.NotEqual(t, allocatedPort, allocatedPort2)
+	// Release the port with the wrong cache entry.
+	hostPortRange.releasePort(allocatedPort, portCacheKey2)
+	// Release the port with the correct cache entry, which overrides the cache entry added above.
+	hostPortRange.releasePort(allocatedPort2, portCacheKey2)
+	assert.False(t, hostPortRange.isAllocated(allocatedPort))
+	assert.False(t, hostPortRange.isAllocated(allocatedPort2))
+
+	{
+		// This should be allocated through the LRU list.
+		allocatedPort3 := hostPortRange.getFreePort(opener, v1.ProtocolTCP, portCacheKey)
+		assert.Equal(t, allocatedPort, allocatedPort3)
+		assert.True(t, hostPortRange.isAllocated(allocatedPort3))
+	}
+	{
+		// This should be allocated through the cache.
+		allocatedPort3 := hostPortRange.getFreePort(opener, v1.ProtocolTCP, portCacheKey2)
+		assert.Equal(t, allocatedPort2, allocatedPort3)
+		assert.True(t, hostPortRange.isAllocated(allocatedPort3))
+	}
+}
+
+func TestPortFromOtherCacheEntryNotPhysicallyReleased(t *testing.T) {
+	socketManager := NewFakeSocketManager()
+	opener := socketManager.openFakeSocket
+	var lowerPort int32 = 1024
+	portCacheKey := "cache"
+	hostPortRange := createCachedHostPortRange(lowerPort, 1025)
+	allocatedPort := hostPortRange.getFreePort(opener, v1.ProtocolTCP, portCacheKey)
+	opener(allocatedPort, v1.ProtocolTCP)
+	// Although the port 1024 is released, it's still bound physically so cannot be allocated again.
+	hostPortRange.releasePort(allocatedPort, portCacheKey)
+	portCacheKey2 := "cache2"
+	assert.True(t, hostPortRange.getFreePort(opener, v1.ProtocolTCP, portCacheKey2) < 0)
+	// The cached port should be released
+	assert.Empty(t, hostPortRange.cache)
+	assert.False(t, hostPortRange.isAllocated(lowerPort))
+	// Now unbinds the physical port
+	socketManager.mem[hostport{port: allocatedPort, protocol: v1.ProtocolTCP}].Close()
+	// Then the port can be allocated again.
+	assert.Equal(t, lowerPort, hostPortRange.getFreePort(opener, v1.ProtocolTCP, portCacheKey2))
+	assert.True(t, hostPortRange.isAllocated(lowerPort))
+}
+
+func TestSameCacheKeyAllocatedMultipleTimes(t *testing.T) {
+	socketManager := NewFakeSocketManager()
+	opener := socketManager.openFakeSocket
+	var lowerPort int32 = 1024
+	portCacheKey := "cache"
+
+	hostPortRange := createCachedHostPortRange(lowerPort, 1026)
+	{
+		allocatedPort := hostPortRange.getFreePort(opener, v1.ProtocolTCP, portCacheKey)
+		assert.True(t, allocatedPort >= lowerPort)
+		allocatedPort2 := hostPortRange.getFreePort(opener, v1.ProtocolTCP, portCacheKey)
+		assert.True(t, allocatedPort2 >= lowerPort)
+		assert.NotEqual(t, allocatedPort, allocatedPort2)
+		// Release the port which goes to the same cache entry.
+		hostPortRange.releasePort(allocatedPort, portCacheKey)
+		assert.False(t, hostPortRange.isAllocated(allocatedPort))
+		// Release the port again to the same cache entry.
+		hostPortRange.releasePort(allocatedPort2, portCacheKey)
+		assert.False(t, hostPortRange.isAllocated(allocatedPort2))
+	}
+	{
+		// Allocate a new port which should be from the cache entry for portCacheKey
+		allocatedPort := hostPortRange.getFreePort(opener, v1.ProtocolTCP, portCacheKey)
+		assert.True(t, allocatedPort >= lowerPort)
+		// Allocate a new port which should be from the LRU list.
+		allocatedPort2 := hostPortRange.getFreePort(opener, v1.ProtocolTCP, "cache2")
+		assert.True(t, allocatedPort2 >= lowerPort)
+		assert.NotEqual(t, allocatedPort, allocatedPort2)
+	}
+}
+
+func TestBypassCache(t *testing.T) {
+	socketManager := NewFakeSocketManager()
+	opener := socketManager.openFakeSocket
+	var lowerPort int32 = 1024
+	portCacheKey := "cache"
+
+	hostPortRange := createCachedHostPortRange(lowerPort, 1026)
+	allocatedPort := hostPortRange.getFreePort(opener, v1.ProtocolTCP, portCacheKey)
+	assert.True(t, allocatedPort >= lowerPort)
+	// Allocate directly
+	allocatedPort2 := hostPortRange.getFreePort(opener, v1.ProtocolTCP, "")
+	assert.True(t, allocatedPort2 >= lowerPort)
+	assert.NotEqual(t, allocatedPort, allocatedPort2)
+	// No available ports left now
+	assert.True(t, hostPortRange.getFreePort(opener, v1.ProtocolTCP, "") < 0)
+	// Release the port which goes to the same cache entry.
+	hostPortRange.releasePort(allocatedPort, portCacheKey)
+	// Allocate the port from the cache although it indicates to bypass the cache.
+	assert.Equal(t, allocatedPort, hostPortRange.getFreePort(opener, v1.ProtocolTCP, ""))
+	assert.True(t, hostPortRange.isAllocated(allocatedPort))
+
+	// The release should bypass the cache too.
+	hostPortRange.releasePort(allocatedPort, "")
+	assert.False(t, hostPortRange.isAllocated(allocatedPort))
+	assert.Empty(t, hostPortRange.cache)
+}
+
+func TestReleaseDuplicatePorts(t *testing.T) {
+	socketManager := NewFakeSocketManager()
+	opener := socketManager.openFakeSocket
+	var lowerPort int32 = 1024
+	portCacheKey := "cache"
+
+	hostPortRange := createCachedHostPortRange(lowerPort, 1025)
+	hostPortRange.releasePort(lowerPort, "")
+	hostPortRange.releasePort(1025, "")
+	allocatedPort := hostPortRange.getFreePort(opener, v1.ProtocolTCP, portCacheKey)
+	assert.Equal(t, lowerPort, allocatedPort)
+	assert.False(t, hostPortRange.getFreePort(opener, v1.ProtocolTCP, portCacheKey) >= lowerPort)
+}
+
+func TestAllocateReleaseWithCacheInParallel(t *testing.T) {
+	t.Parallel()
+	opener := NewFakeSocketManager().openFakeSocket
+	var upperPort int32 = 1200
+	var lowerPort int32 = 1025
+	hostPortRange := createCachedHostPortRange(lowerPort, upperPort)
+
+	runTimes := 512
+	wg := sync.WaitGroup{}
+	wg.Add(runTimes)
+	for i := 0; i < runTimes; i += 1 {
+		go func(index int) {
+			cacheKey := fmt.Sprintf("container-%d", index % 3)
+			defer wg.Done()
+			time.Sleep(time.Duration(rand.Intn(20)) * time.Millisecond)
+			var port int32
+			for {
+				if port = hostPortRange.getFreePort(opener, v1.ProtocolTCP, cacheKey); port > 0 {
+					assert.True(t, port >= lowerPort && port < upperPort)
+					break
+				}
+				time.Sleep(time.Duration(rand.Intn(20)) * time.Millisecond)
+			}
+			time.Sleep(time.Duration(rand.Intn(20)) * time.Millisecond)
+			hostPortRange.releasePort(port, cacheKey)
+		}(i)
+	}
+	wg.Wait()
+
+	for port := lowerPort; port < upperPort; port += 1 {
+		assert.False(t, hostPortRange.isAllocated(port), "Port %d was not released")
+	}
+}

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
@@ -259,7 +259,7 @@ func TestGenerateContainerConfig(t *testing.T) {
 	}
 
 	expectedConfig := makeExpectedConfig(m, pod, 0)
-	containerConfig, err := m.generateContainerConfig(&pod.Spec.Containers[0], pod, 0, "", pod.Spec.Containers[0].Image)
+	containerConfig, err := m.generateContainerConfig(&pod.Spec.Containers[0], pod, 0, "", pod.Spec.Containers[0].Image, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedConfig, containerConfig, "generate container config for kubelet runtime v1.")
 
@@ -288,7 +288,7 @@ func TestGenerateContainerConfig(t *testing.T) {
 		},
 	}
 
-	_, err = m.generateContainerConfig(&podWithContainerSecurityContext.Spec.Containers[0], podWithContainerSecurityContext, 0, "", podWithContainerSecurityContext.Spec.Containers[0].Image)
+	_, err = m.generateContainerConfig(&podWithContainerSecurityContext.Spec.Containers[0], podWithContainerSecurityContext, 0, "", podWithContainerSecurityContext.Spec.Containers[0].Image, nil)
 	assert.Error(t, err)
 
 	imageId, _ := imageService.PullImage(&runtimeapi.ImageSpec{Image: "busybox"}, nil)
@@ -300,7 +300,7 @@ func TestGenerateContainerConfig(t *testing.T) {
 	podWithContainerSecurityContext.Spec.Containers[0].SecurityContext.RunAsUser = nil
 	podWithContainerSecurityContext.Spec.Containers[0].SecurityContext.RunAsNonRoot = &runAsNonRootTrue
 
-	_, err = m.generateContainerConfig(&podWithContainerSecurityContext.Spec.Containers[0], podWithContainerSecurityContext, 0, "", podWithContainerSecurityContext.Spec.Containers[0].Image)
+	_, err = m.generateContainerConfig(&podWithContainerSecurityContext.Spec.Containers[0], podWithContainerSecurityContext, 0, "", podWithContainerSecurityContext.Spec.Containers[0].Image, nil)
 	assert.Error(t, err, "RunAsNonRoot should fail for non-numeric username")
 }
 


### PR DESCRIPTION
1. The kubelet is responsible to manage the host port ranges locally. It's assumed that there are plenty of host ports so the scheduler does not need to be aware of the host port allocation.
2. Because the host port is dynamically allocated locally, each pod in the same deployment/statefulset can have different port. The port discovery will be an issue. The change assume the application handles the port discovery, for example, registration through ZK.
3. The host port allocation is only enabled for the pods which use host network.
4. The dynamically allocated host ports are dividied into different ranges, where each range may be used to indicate the QoS of the ports. Currently three QoS bands are defined: BE (best effort), AF1(assured forwarding 1), AF4(assured forwarding 4). AF4 has the highest QoS while BE has the lowest. Note that the QoS needs to be enforced externally. Kubelet does not enforce the QoS.
5. A pod container declares it needs a host port allocation through environment variables with the format "PORTALLOC_(TCP|UDP)_<unique port name>". The container can reference the allocated:
  - In command lines referencing the Env variable through "$(PORTALLOC_(TCP|UDP)_<unique port name>)".
  - Referencing the Env variable directly from within the container.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
